### PR TITLE
Fix main thread requirement crash

### DIFF
--- a/CalendarManager/CalendarManager.m
+++ b/CalendarManager/CalendarManager.m
@@ -21,6 +21,11 @@
 
 @implementation CalendarManager
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(addEvent:(NSDictionary *)details callback:(RCTResponseSenderBlock)callback)
@@ -50,20 +55,25 @@ RCT_EXPORT_METHOD(addEvent:(NSDictionary *)details callback:(RCTResponseSenderBl
     event.URL = URL;
     event.location = location;
 
-    EKEventEditViewController *editEventController = [[EKEventEditViewController alloc] init];
-    editEventController.event = event;
-    editEventController.eventStore = self.eventStore;
-    editEventController.editViewDelegate = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      EKEventEditViewController *editEventController = [[EKEventEditViewController alloc] init];
+      editEventController.event = event;
+      editEventController.eventStore = self.eventStore;
+      editEventController.editViewDelegate = self;
 
-    UIViewController *root = RCTPresentedViewController();
-    [root presentViewController:editEventController animated:YES completion:nil];
+      UIViewController *root = RCTPresentedViewController();
+      [root presentViewController:editEventController animated:YES completion:nil];
+    });
+
 }
 
 #pragma mark - EventView delegate
 
 - (void)eventEditViewController:(EKEventEditViewController *)controller didCompleteWithAction:(EKEventEditViewAction)action
 {
+  dispatch_async(dispatch_get_main_queue(), ^{
     [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+  });
 }
 
 - (void)initEventStoreWithCalendarCapabilities:(NSDictionary *)details callback:(RCTResponseSenderBlock)callback

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/react-native-calendar-manager",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A calendar manager for react-native",
   "main": "index",
   "repository": {


### PR DESCRIPTION
Fixes app crash when adding events for a second time in same runtime (without restarting app). 

Issue was with UI operations requiring main thread execution which was only being given on first execute, not on second.